### PR TITLE
Allow the R97 and CAR to use the holosight

### DIFF
--- a/cfg/server/persistent_player_data_version_299.pdef
+++ b/cfg/server/persistent_player_data_version_299.pdef
@@ -528,6 +528,21 @@ $ENUM_START modsCombined
 	mp_titanweapon_xo16_burst
 	mp_titanweapon_xo16_extended_ammo
 	mp_titanweapon_xo16_fast_reload
+
+	// R1 Delta custom stuff
+	mp_weapon_car_holosight
+	mp_weapon_r97_holosight
+
+	// Disabled for now
+/*
+	mp_weapon_autopistol_extended_ammo
+	mp_weapon_autopistol_starburst
+
+	mp_weapon_semipistol_extended_ammo
+	mp_weapon_semipistol_silencer
+
+	mp_weapon_wingman_silencer
+*/
 $ENUM_END
 
 $ENUM_START unlockRefs

--- a/scripts/vscripts/_items.nut
+++ b/scripts/vscripts/_items.nut
@@ -683,8 +683,28 @@ function InitItems()
 	CreateDecalData( itemType.TITAN_DECAL, "titan_decals_3s_marked4death",	"#TITAN_DECALS_3S_MARKED4DEATH_NAME",	"#TITAN_DECALS_3S_MARKED4DEATH_DESC",	"#TITAN_DECALS_3S_MARKED4DEATH_REQ",	"#TITAN_DECALS_3S_MARKED4DEATH_REQUNLOCKED",	"../models/titans/custom_decals/decal_pack_01/titan_decals_3S_marked4death_menu",	false )
 	CreateDecalData( itemType.TITAN_DECAL, "titan_decals_3s_pilothunter",	"#TITAN_DECALS_3S_PILOTHUNTER_NAME",	"#TITAN_DECALS_3S_PILOTHUNTER_DESC",	"#TITAN_DECALS_3S_PILOTHUNTER_REQ",		"#TITAN_DECALS_3S_PILOTHUNTER_REQUNLOCKED",		"../models/titans/custom_decals/decal_pack_01/titan_decals_3S_pilothunter_menu",	false )
 
+	// R1 Delta custom stuff
+	// When you add anything here, the game will start looking for [WEAPON_NAME] + [MOD_NAME] (ex: mp_weapon_car_holosight, mp_weapon_autopistol_starburst )
+	// So make sure you also have new entries for them in _pdef.nut and persistent_player_data_version_299.pdef
 
+	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_car_grunt_kills", 		1,		"mp_weapon_car",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
+	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_r97_grunt_kills", 		1,		"mp_weapon_r97",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
 
+	// Disabled for now - see: https://discord.com/channels/1186901921567617115/1186907055840301086/1368994432996606034
+
+	// "true like i was debating if i should make holosight usable for R-97 and CAR"
+	// "those are probably fine but compared to pistol perks, pistol probably shouldn't have pekrs"
+	// "Probably not on the main game experience, but would be nice to have it as a mod. just for fun"
+
+/*
+	CreateModData( itemType.PILOT_PRIMARY_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_spectre_kills", 		1, 		"mp_weapon_autopistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 10, 			"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
+	CreateModData( itemType.PILOT_PRIMARY_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_pilot_kills", 		1, 		"mp_weapon_autopistol",		"starburst",					"#MOD_STARBURST_NAME",			"#MOD_STARBURST_DESC",				"#MOD_STARBURST_LONGDESC",				0, -5, 0, 10, 0, 		"../ui/menu/items/mod_icons/starburst", 			"../ui/menu/items/mod_icons/starburst" )
+
+	CreateModData( itemType.PILOT_PRIMARY_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_spectre_kills", 		1, 		"mp_weapon_semipistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 3, 			"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
+	CreateModData( itemType.PILOT_PRIMARY_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_kills", 				1, 		"mp_weapon_semipistol",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-5, -5, -2, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
+
+	CreateModData( itemType.PILOT_PRIMARY_MOD,		DEV_ENABLED,	0, 	"ch_wingman_kills", 				1, 		"mp_weapon_wingman",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-10, 0, -5, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
+*/
 
 	// Sort some items based on unlock level
 	itemsOfType[itemType.PILOT_PRIMARY].sort( SortByUnlockReq )

--- a/scripts/vscripts/_pdef.nut
+++ b/scripts/vscripts/_pdef.nut
@@ -553,7 +553,22 @@ function InitPersistence()
 	    ["mp_titanweapon_xo16_accelerator"] = 89,
 	    ["mp_titanweapon_xo16_burst"] = 90,
 	    ["mp_titanweapon_xo16_extended_ammo"] = 91,
-	    ["mp_titanweapon_xo16_fast_reload"] = 92
+	    ["mp_titanweapon_xo16_fast_reload"] = 92,
+
+		// R1 Delta custom stuff
+	    ["mp_weapon_car_holosight"] = 93,
+	    ["mp_weapon_r97_holosight"] = 94 // <- Add a comma if you re-enable the mods below
+
+		// Disabled for now
+/*
+	    mp_weapon_autopistol_extended_ammo = 95,
+	    mp_weapon_autopistol_starburst = 96,
+
+	    mp_weapon_semipistol_extended_ammo = 97,
+	    mp_weapon_semipistol_silencer = 98,
+
+	    mp_weapon_wingman_silencer = 99
+*/
     }
 
     AddPersistenceEnum("modsCombined", modsCombined)


### PR DESCRIPTION
Allows the R97 and CAR to use the holosight. I also included some stuff that gives pistols some mods, but they're disabled by default. See: https://discord.com/channels/1186901921567617115/1186907055840301086/1368994432996606034

Ignore the weird sounds, no idea whats up with that

https://github.com/user-attachments/assets/56bc77ad-8cbf-4986-8315-146675246a55

https://github.com/user-attachments/assets/f249e66a-4742-4f1e-b7b1-3660e35c0559

