### PR TITLE
Fix hardpoint voicelines overlapping gamemode announcement

### DIFF
--- a/scripts/vscripts/mp/capture_point.nut
+++ b/scripts/vscripts/mp/capture_point.nut
@@ -1644,16 +1644,16 @@ function CapturePointKillScoreEvent( victim, player )
 }
 
 //////////////////////////////////////////////////////////
-function CapturePointVO_Allowed()
+function CapturePointVO_Allowed( player )
 {
-	return GetGameState() == eGameState.Playing
+	return ( GetGameState() == eGameState.Playing && player.s.hasDoneTryGameModeAnnouncement )
 }
 
 
 //////////////////////////////////////////////////////////
 function CapturePointVO_Approaching( player, hardpoint, distance )
 {
-	if ( !CapturePointVO_Allowed() )
+	if ( !CapturePointVO_Allowed( player ) )
 		return
 
 	local team = player.GetTeam()
@@ -1706,7 +1706,7 @@ function CapturePointVO_Approaching( player, hardpoint, distance )
 //////////////////////////////////////////////////////////
 function CapturePointVO_Nag( player )
 {
-	if ( !CapturePointVO_Allowed() )
+	if ( !CapturePointVO_Allowed( player ) )
 		return
 
 	Assert( player.IsPlayer() )


### PR DESCRIPTION
Fixes hardpoint voicelines overlapping the gamemode announcement. The easiest way i got this to happen was to spawn as the militia in airbase

Before:

https://github.com/user-attachments/assets/e94ec530-e181-48a7-9e4a-e41490dee20a

After:

https://github.com/user-attachments/assets/7e1ec70b-f90c-4003-8c41-e7c6820cab63

