### PR TITLE
Add R97 AOG

### DIFF
--- a/scripts/vscripts/_items.nut
+++ b/scripts/vscripts/_items.nut
@@ -682,29 +682,7 @@ function InitItems()
 	CreateDecalData( itemType.TITAN_DECAL, "titan_decals_3s_marked4death",	"#TITAN_DECALS_3S_MARKED4DEATH_NAME",	"#TITAN_DECALS_3S_MARKED4DEATH_DESC",	"#TITAN_DECALS_3S_MARKED4DEATH_REQ",	"#TITAN_DECALS_3S_MARKED4DEATH_REQUNLOCKED",	"../models/titans/custom_decals/decal_pack_01/titan_decals_3S_marked4death_menu",	false )
 	CreateDecalData( itemType.TITAN_DECAL, "titan_decals_3s_pilothunter",	"#TITAN_DECALS_3S_PILOTHUNTER_NAME",	"#TITAN_DECALS_3S_PILOTHUNTER_DESC",	"#TITAN_DECALS_3S_PILOTHUNTER_REQ",		"#TITAN_DECALS_3S_PILOTHUNTER_REQUNLOCKED",		"../models/titans/custom_decals/decal_pack_01/titan_decals_3S_pilothunter_menu",	false )
 
-	// R1 Delta custom stuff
-	// When you add anything here, the game will start looking for [WEAPON_NAME] + [MOD_NAME] (ex: mp_weapon_car_holosight, mp_weapon_autopistol_starburst )
-	// So make sure you also have new entries for them in _pdef.nut and persistent_player_data_version_299.pdef
-
-	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_car_grunt_kills", 		1,		"mp_weapon_car",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
-	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_r97_grunt_kills", 		1,		"mp_weapon_r97",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
-
-	// Disabled for now - see: https://discord.com/channels/1186901921567617115/1186907055840301086/1368994432996606034
-
-	// "true like i was debating if i should make holosight usable for R-97 and CAR"
-	// "those are probably fine but compared to pistol perks, pistol probably shouldn't have pekrs"
-	// "Probably not on the main game experience, but would be nice to have it as a mod. just for fun"
-
-
-	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_spectre_kills", 		1, 		"mp_weapon_autopistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 10, 			"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
-	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_kills", 				1, 		"mp_weapon_autopistol",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-5, -5, -5, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
-	//CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_pilot_kills", 		1, 		"mp_weapon_autopistol",		"starburst",					"#MOD_STARBURST_NAME",			"#MOD_STARBURST_DESC",				"#MOD_STARBURST_LONGDESC",				0, -5, 0, 10, 0, 		"../ui/menu/items/mod_icons/starburst", 			"../ui/menu/items/mod_icons/starburst" )
-
-	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_spectre_kills", 		1, 		"mp_weapon_semipistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 3, 			"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
-	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_kills", 				1, 		"mp_weapon_semipistol",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-5, -5, -2, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
-
-	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_wingman_kills", 				1, 		"mp_weapon_wingman",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-10, 0, -5, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
-
+	CreateR1DeltaItems()
 
 	// Sort some items based on unlock level
 	itemsOfType[itemType.PILOT_PRIMARY].sort( SortByUnlockReq )
@@ -741,6 +719,36 @@ function InitItems()
 		if ( IsClient() )
 			PrecacheHUDMaterial( MOD_ICON_NONE )
 	}
+}
+
+function CreateR1DeltaItems()
+{
+	local HideFromMenus = false
+
+	// R1 Delta custom stuff
+	// When you add a new item here, the game will start looking for it in _pdef.nut
+	// If its a mod or attachment, the game will look for [WEAPON_NAME] + [MOD_NAME] (ex: mp_weapon_car_holosight, mp_weapon_autopistol_starburst )
+	// So make sure to add it to the right category
+
+	////////////////////
+	//PILOT ATTACHMENT DATA
+	////////////////////
+	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_car_grunt_kills", 		1,		"mp_weapon_car",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
+	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_r97_grunt_kills", 		1,		"mp_weapon_r97",		"holosight",	"#MOD_HOLOSIGHT_NAME",		"#MOD_HOLOSIGHT_DESC",		"#MOD_HOLOSIGHT_LONGDESC",				"../ui/menu/items/attachment_icons/holosight", 			"../ui/menu/items/attachment_icons/holosight" )
+	//CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_car_kills",		 		2,		"mp_weapon_car",		"aog",			"#MOD_AOG_NAME",			"#MOD_AOG_DESC",			"#MOD_AOG_LONGDESC",					"../ui/menu/items/attachment_icons/aog", 				"../ui/menu/items/attachment_icons/aog" )
+	CreateAttachmentData( itemType.PILOT_PRIMARY_ATTACHMENT,	DEV_ENABLED,	0, 		"ch_r97_kills",		 		2,		"mp_weapon_r97",		"aog",			"#MOD_AOG_NAME",			"#MOD_AOG_DESC",			"#MOD_AOG_LONGDESC",					"../ui/menu/items/attachment_icons/aog", 				"../ui/menu/items/attachment_icons/aog" )
+
+	////////////////////
+	//PILOT MOD DATA
+	////////////////////
+	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_spectre_kills", 		1, 		"mp_weapon_autopistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 10, 		"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
+	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_kills", 				1, 		"mp_weapon_autopistol",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-5, -5, -5, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
+	//CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_autopistol_pilot_kills", 		1, 		"mp_weapon_autopistol",		"starburst",					"#MOD_STARBURST_NAME",			"#MOD_STARBURST_DESC",				"#MOD_STARBURST_LONGDESC",				0, -5, 0, 10, 0, 		"../ui/menu/items/mod_icons/starburst", 			"../ui/menu/items/mod_icons/starburst" )
+
+	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_spectre_kills", 		1, 		"mp_weapon_semipistol",		"extended_ammo",				"#MOD_EXTENDED_MAG_NAME",		"#MOD_EXTENDED_MAG_DESC",			"#MOD_EXTENDED_MAG_LONGDESC",			0, 0, 0, 0, 3, 			"../ui/menu/items/mod_icons/extended_ammo", 		"../ui/menu/items/mod_icons/extended_ammo" )
+	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_semipistol_kills", 				1, 		"mp_weapon_semipistol",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-5, -5, -2, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
+
+	CreateModData( itemType.PILOT_SIDEARM_MOD,		DEV_ENABLED,	0, 	"ch_wingman_kills", 				1, 		"mp_weapon_wingman",		"silencer",						"#MOD_SILENCER_NAME",			"#MOD_SILENCER_DESC",				"#MOD_SILENCER_LONGDESC",				-10, 0, -5, 0, 0, 		"../ui/menu/items/mod_icons/silencer", 				"../ui/menu/items/mod_icons/silencer" )
 }
 
 function CreateWeaponData( type, dev_enabled, levelReq, challengeReq, challengeTier, ref, image, icon = null, altImage = null )

--- a/scripts/vscripts/_pdef.nut
+++ b/scripts/vscripts/_pdef.nut
@@ -559,17 +559,17 @@ function InitPersistence()
 
 		// R1 Delta custom stuff
 	    ["mp_weapon_car_holosight"] = 93,
-	    ["mp_weapon_r97_holosight"] = 94, // <- Add a comma if you re-enable the mods below
-		// Disabled for now
-	    ["mp_weapon_autopistol_extended_ammo"] = 95,
-	    ["mp_weapon_autopistol_silencer"] = 96,
+	    ["mp_weapon_r97_holosight"] = 94,
+	    ["mp_weapon_car_aog"] = 95,
+	    ["mp_weapon_r97_aog"] = 96,
 
-	    ["mp_weapon_semipistol_extended_ammo"] = 97,
-	    ["mp_weapon_semipistol_silencer"] = 98,
+	    ["mp_weapon_autopistol_extended_ammo"] = 97,
+	    ["mp_weapon_autopistol_silencer"] = 98,
 
-	    ["mp_weapon_wingman_silencer"] = 99,
-	    ["mp_weapon_smr_tank_buster"] = 100
+	    ["mp_weapon_semipistol_extended_ammo"] = 99,
+	    ["mp_weapon_semipistol_silencer"] = 100,
 
+	    ["mp_weapon_wingman_silencer"] = 101
     }
 
     AddPersistenceEnum("modsCombined", modsCombined)

--- a/scripts/weapons/mp_weapon_r97.txt
+++ b/scripts/weapons/mp_weapon_r97.txt
@@ -436,6 +436,13 @@ WeaponData
 			"anim_alt_idleAttack" 							"1"
 			"zoom_fov"										"45"
 		}
+		aog
+		{
+			"bodygroup2_set"		"1"
+			"bodygroup1_set"		"0"
+			"anim_alt_idleAttack"	"3"
+			"zoom_fov"				"30"
+		}
 	}
 
 	CrosshairData
@@ -467,28 +474,11 @@ WeaponData
 		}
 		Burn_Mod //Match BaseWeapon + default color change until override setting.
 		{
+			"inherit_data_from"				"BaseWeapon"
+
 			DefaultElementBehavior
 			{
-				"rotation"					"90"
-				"size_x"					"44"
-				"size_y"					"44"
-				"scale_ads"					"0.5"
-				"fade_while_sprinting"		"1"
-				"fade_while_reloading"		"1"
-				"draw_while_ads"			"0"
-				"draw_while_hip"			"1"
-				"fade_while_zooming"		"1"
 				"default_color"				"246 134 40 255"
-			}
-			Element0
-			{
-				"type"						"spread"
-				"material"					"hud/crosshairs/standard_plus"
-			}
-			Element1
-			{
-				"type"						"spread"
-				"material"					"hud/crosshairs/standard_plus_shadow"
 			}
 		}
 	}


### PR DESCRIPTION
Lets the R97 use the aog. The car can use it too, but it needs custom animations so thats not happenning for now sadly.

https://github.com/user-attachments/assets/2bd47db0-94e2-4bc5-b0d0-1f5673454d05

I also updated some of the comments, and moved the custom item registration into a separate function. It was kinda weird to randomly have them in the middle of the other one